### PR TITLE
automatically apply library patches

### DIFF
--- a/Firmware/README.md
+++ b/Firmware/README.md
@@ -1,24 +1,10 @@
 # Firmware
 
-The badge code is written in C++ using PlatformIO in VSCode. Compiling from source is an involved process and I can guarantee I've missed some steps here.
+The badge code is written in C++ using PlatformIO in VSCode.
 
-Install VSCode. 
-Add the PlatformIO extension.
-Open the Saintcon2023 folder in VSCode. PlatformIO should automatically setup the project for you and download the required libraries, etc.
-You'll need to make a few changes for it to compile:
-- Open this file: `.pio\libdeps\esp32-s3-devkitc-1\GFX Library for Arduino\src\databus\Arduino_ESP32LCD8.cpp`
-- Comment out most of the function `void Arduino_ESP32LCD8::writePixels`, leaving just this at the end:
-`while (len--)
-  {
-    _data16.value = *data++;
-    LCD_CAM.lcd_cmd_val.lcd_cmd_value = _data16.msb;
-    WAIT_LCD_NOT_BUSY;
-    LCD_CAM.lcd_user.val = LCD_CAM_LCD_CMD | LCD_CAM_LCD_UPDATE_REG | LCD_CAM_LCD_START;
-    LCD_CAM.lcd_cmd_val.lcd_cmd_value = _data16.lsb;
-    WAIT_LCD_NOT_BUSY;
-    LCD_CAM.lcd_user.val = LCD_CAM_LCD_CMD | LCD_CAM_LCD_UPDATE_REG | LCD_CAM_LCD_START;
-  }`
-- Open this file: `.pio\libdeps\esp32-s3-devkitc-1\WebServer_ESP32_W6100\src\WebServer_ESP32_W6100.hpp`
-- Comment out this line: `#include <WebServer.h> // Introduce corresponding libraries`
+- Install [VSCode](https://code.visualstudio.com/download).
+- Add the [PlatformIO extension](https://marketplace.visualstudio.com/items?itemName=platformio.platformio-ide).
+- Open the Saintcon2023 folder in VSCode. PlatformIO should automatically setup the project for you and download the required libraries, etc.
+- Choose `> PlatformIO: Upload` from the VSCode actions chooser (`Control/CMD + Shift + P`).
 
-I'm sure there are other things. Please let me know or submit a pull request.
+Please send pull suggestions or pull requests if there's anything missing!

--- a/Firmware/Source/apply_patches.py
+++ b/Firmware/Source/apply_patches.py
@@ -1,0 +1,44 @@
+# Adapted from https://docs.platformio.org/en/stable/scripting/examples/override_package_files.html
+
+
+"""
+Patches were generated with the following commands:
+diff '.pio/libdeps/esp32-s3-devkitc-1/WebServer_ESP32_W6100/src/WebServer_ESP32_W6100.hpp' /tmp/WebServer_ESP32_W6100.hpp > patches/dont-include-webserver-h.patch
+diff '.pio/libdeps/esp32-s3-devkitc-1/GFX Library for Arduino/src/databus/Arduino_ESP32LCD8.cpp' /tmp/Arduino_ESP32LCD8.cpp > patches/fix-esp32lcd8-write-pixels.patch
+"""
+
+
+from os.path import isfile
+from pathlib import Path
+
+Import("env")
+
+LIBDEPS_DIR: Path = Path(env.subst("$PROJECT_DIR")) / ".pio" / "libdeps" /env.subst("$PIOENV")
+LIBDEPS_PATCHFLAG_PATH: Path = Path(LIBDEPS_DIR / ".patching-done")
+PATCHES_DIR: Path = Path(env.subst("$PROJECT_DIR")) / "patches"
+
+# patch file only if we didn't do it before
+if not isfile(LIBDEPS_PATCHFLAG_PATH):
+
+    files_to_patch = [
+        (
+            LIBDEPS_DIR / "WebServer_ESP32_W6100" / "src" / "WebServer_ESP32_W6100.hpp",
+            PATCHES_DIR / "dont-include-webserver-h.patch",
+        ),
+        (
+            LIBDEPS_DIR / "GFX Library for Arduino" / "src" / "databus" / "Arduino_ESP32LCD8.cpp",
+            PATCHES_DIR / "fix-esp32lcd8-write-pixels.patch",
+        ),
+    ]
+
+    for original_file, patch_file in files_to_patch:
+        print("Patching {} with {}".format(original_file, patch_file))
+        if not original_file.is_file():
+            raise Exception("Library file {} does not exist".format(original_file))
+        if not patch_file.is_file():
+            raise Exception("Patch file {} does not exist".format(patch_file))
+
+        # -l means ignore whitespace
+        env.Execute("patch -l '{}' '{}'".format(original_file, patch_file))
+
+    Path(LIBDEPS_PATCHFLAG_PATH).touch()

--- a/Firmware/Source/patches/dont-include-webserver-h.patch
+++ b/Firmware/Source/patches/dont-include-webserver-h.patch
@@ -1,0 +1,2 @@
+32d31
+< #include <WebServer.h> // Introduce corresponding libraries

--- a/Firmware/Source/patches/fix-esp32lcd8-write-pixels.patch
+++ b/Firmware/Source/patches/fix-esp32lcd8-write-pixels.patch
@@ -1,0 +1,86 @@
+434,516c434
+<   uint32_t xferLen, l;
+< 
+<   if (esp_ptr_dma_capable(data))
+<   {
+<     while (len > (USE_DMA_THRESHOLD)) // While pixels remain
+<     {
+<       xferLen = (len >= LCD_MAX_PIXELS_AT_ONCE) ? (LCD_MAX_PIXELS_AT_ONCE) : len; // How many this pass?
+< 
+<       _data16.value = *data++;
+<       _data32.value = 0;
+<       _data32.lsb = _data16.msb;
+<       _data32.lsb_2 = _data16.lsb;
+< 
+<       LCD_CAM.lcd_cmd_val.val = _data32.value;
+<       WAIT_LCD_NOT_BUSY;
+<       LCD_CAM.lcd_user.val = LCD_CAM_LCD_CMD | LCD_CAM_LCD_CMD_2_CYCLE_EN | LCD_CAM_LCD_UPDATE_REG | LCD_CAM_LCD_START;
+< 
+<       _data16.value = *data++;
+<       _data32.value = 0;
+<       _data32.lsb = _data16.msb;
+<       _data32.lsb_2 = _data16.lsb;
+< 
+<       l = xferLen - 2;
+<       l <<= 1;
+<       *(uint32_t *)_dmadesc = ((l + 3) & (~3)) | l << 12 | 0xC0000000;
+<       _dmadesc->buffer = data;
+<       _dmadesc->next = nullptr;
+<       gdma_start(_dma_chan, (intptr_t)(_dmadesc));
+<       LCD_CAM.lcd_cmd_val.val = _data32.value;
+<       LCD_CAM.lcd_user.val = LCD_CAM_LCD_ALWAYS_OUT_EN | LCD_CAM_LCD_DOUT | LCD_CAM_LCD_CMD | LCD_CAM_LCD_CMD_2_CYCLE_EN | LCD_CAM_LCD_UPDATE_REG;
+< 
+<       data += xferLen - 2;
+<       len -= xferLen;
+< 
+<       WAIT_LCD_NOT_BUSY;
+<       LCD_CAM.lcd_user.val = LCD_CAM_LCD_ALWAYS_OUT_EN | LCD_CAM_LCD_DOUT | LCD_CAM_LCD_CMD | LCD_CAM_LCD_CMD_2_CYCLE_EN | LCD_CAM_LCD_START;
+<     }
+<   }
+<   else
+<   {
+<     while (len > (USE_DMA_THRESHOLD)) // While pixels remain
+<     {
+<       xferLen = (len >= LCD_MAX_PIXELS_AT_ONCE) ? (LCD_MAX_PIXELS_AT_ONCE) : len; // How many this pass?
+< 
+<       _data16.value = *data++;
+<       _data32.value = 0;
+<       _data32.lsb = _data16.msb;
+<       _data32.lsb_2 = _data16.lsb;
+< 
+<       LCD_CAM.lcd_cmd_val.val = _data32.value;
+<       WAIT_LCD_NOT_BUSY;
+<       LCD_CAM.lcd_user.val = LCD_CAM_LCD_CMD | LCD_CAM_LCD_CMD_2_CYCLE_EN | LCD_CAM_LCD_UPDATE_REG | LCD_CAM_LCD_START;
+< 
+<       _data16.value = *data++;
+<       _data32.value = 0;
+<       _data32.lsb = _data16.msb;
+<       _data32.lsb_2 = _data16.lsb;
+< 
+<       l = xferLen - 2;
+<       l <<= 1;
+<       for (uint32_t i = 0; i < l;)
+<       {
+<         _data16.value = *data++;
+<         _buffer[i++] = _data16.msb;
+<         _buffer[i++] = _data16.lsb;
+<       }
+< 
+<       *(uint32_t *)_dmadesc = ((l + 3) & (~3)) | l << 12 | 0xC0000000;
+<       _dmadesc->buffer = _buffer32;
+<       _dmadesc->next = nullptr;
+<       gdma_start(_dma_chan, (intptr_t)(_dmadesc));
+<       LCD_CAM.lcd_cmd_val.val = _data32.value;
+<       LCD_CAM.lcd_user.val = LCD_CAM_LCD_ALWAYS_OUT_EN | LCD_CAM_LCD_DOUT | LCD_CAM_LCD_CMD | LCD_CAM_LCD_CMD_2_CYCLE_EN | LCD_CAM_LCD_UPDATE_REG;
+< 
+<       len -= xferLen;
+< 
+<       WAIT_LCD_NOT_BUSY;
+<       LCD_CAM.lcd_user.val = LCD_CAM_LCD_ALWAYS_OUT_EN | LCD_CAM_LCD_DOUT | LCD_CAM_LCD_CMD | LCD_CAM_LCD_CMD_2_CYCLE_EN | LCD_CAM_LCD_START;
+<     }
+<   }
+< 
+<   while (len--)
+<   {
+---
+>   while (len--) {

--- a/Firmware/Source/platformio.ini
+++ b/Firmware/Source/platformio.ini
@@ -30,3 +30,4 @@ lib_deps =
 	bblanchon/ArduinoJson@^6.21.3
 	khoih-prog/AsyncHTTPSRequest_Generic @ ^2.5.0
 	crankyoldgit/IRremoteESP8266 @ ^2.8.6
+extra_scripts = pre:apply_patches.py


### PR DESCRIPTION
PlatformIO has [a doc](https://docs.platformio.org/en/stable/scripting/examples/override_package_files.html) describing how to use a `pre` script to automatically apply patches to libraries. This PR sets up the patches required for this project, and updates the README accordingly.

Thanks for your awesome work!