### PR TITLE
Fixed minor bugs to make it build

### DIFF
--- a/Firmware/Source/include/Keyboard.hpp
+++ b/Firmware/Source/include/Keyboard.hpp
@@ -1,7 +1,7 @@
 #ifndef _KEYBOARD_H_
 #define _KEYBOARD_H_
 
-#include <arduino.h>
+#include <Arduino.h>
 
 #define KEY_UP      0
 #define KEY_DOWN    1

--- a/Firmware/Source/screenFix.sh
+++ b/Firmware/Source/screenFix.sh
@@ -1,0 +1,12 @@
+# This scripts will fix the GLX issue from PlatformIO as stated in ../README.md 
+
+sed -i '/Arduino_ESP32LCD8::writePixels(uint16_t \*data, uint32_t len)/,/while (len--)/ {
+    /Arduino_ESP32LCD8::writePixels(uint16_t \*data, uint32_t len)/! {
+        /while (len--)/! s/^/\/\/ /
+    }
+}' ".pio/libdeps/esp32-s3-devkitc-1/GFX Library for Arduino/src/databus/Arduino_ESP32LCD8.cpp"
+
+sed -i '/Arduino_ESP32LCD8::writePixels(uint16_t \*data, uint32_t len)/ {
+    n;
+    s/^\/\/ //;
+}' ".pio/libdeps/esp32-s3-devkitc-1/GFX Library for Arduino/src/databus/Arduino_ESP32LCD8.cpp"

--- a/Firmware/Source/src/main.cpp
+++ b/Firmware/Source/src/main.cpp
@@ -3,6 +3,7 @@
 #include <Arduino_GFX_Library.h>
 #include <Wire.h>
 #include <WiFi.h>
+#include <WebServer.h>
 #include <HTTPClient.h>
 #include <sclogo.h>
 #include <FS.h>


### PR DESCRIPTION
In order for it to build in my Linux environment I had to make the following changes:

In Keyboard.hpp: `#include <arduino.h>`  needs to be `#include <Arduino.h>` to match casing

In main.cpp: Needed to add `#include <WebServer.h>` in order for it to build properly according to [this](https://community.platformio.org/t/pio-libdeps-esp32doit-devkit-v1-esp-async-webserver-src-espasyncwebserver-h18-fatal-error-wifi-h-no-such-file-or-directory/21940/5) forum. Something with PlatformIO not wanting to include it unless it was also included in your main file.  This is a fix for what the README.md file says about having to comment out `#include <WebServer.h>` in `.pio\libdeps\esp32-s3-devkitc-1\WebServer_ESP32_W6100\src\WebServer_ESP32_W6100.hpp`